### PR TITLE
Fixed placeholder position on iOS 7

### DIFF
--- a/SAMTextField/SAMTextField.h
+++ b/SAMTextField/SAMTextField.h
@@ -11,6 +11,20 @@
  */
 @interface SAMTextField : UITextField
 
+///------------------------------------
+/// @name Accessing the Text Attributes
+///------------------------------------
+
+/**
+ The color of the placeholder text.
+ 
+ This property applies to the entire placeholder text string. The default value for this property is set by the system.
+ Setting this property to `nil` will use the system placeholder text color.
+ 
+ The default value is `nil`.
+ */
+@property (nonatomic, strong) UIColor *placeholderTextColor;
+
 ///------------------------------
 /// @name Drawing and Positioning
 ///------------------------------

--- a/SAMTextField/SAMTextField.m
+++ b/SAMTextField/SAMTextField.m
@@ -10,6 +10,16 @@
 
 @implementation SAMTextField
 
+#pragma mark - Accessors
+
+- (void)setPlaceholderTextColor:(UIColor *)placeholderTextColor {
+	_placeholderTextColor = placeholderTextColor;
+	
+	if (!self.text && self.placeholder) {
+		[self setNeedsDisplay];
+	}
+}
+
 #pragma mark - UIView
 
 - (id)initWithCoder:(NSCoder *)aDecoder {
@@ -26,7 +36,6 @@
     }
     return self;
 }
-
 
 #pragma mark - UITextField
 
@@ -54,12 +63,36 @@
     return UIEdgeInsetsInsetRect([super leftViewRectForBounds:bounds], self.leftViewInsets);
 }
 
+- (void)drawPlaceholderInRect:(CGRect)rect {
+	if (!_placeholderTextColor) {
+		[super drawPlaceholderInRect:rect];
+		return;
+	}
+	
+    [_placeholderTextColor setFill];
+    
+    //check iOS version is >= 7.0
+    if (([[[UIDevice currentDevice] systemVersion] compare:@"7.0" options:NSNumericSearch] != NSOrderedAscending)) {
+        rect =  CGRectInset(rect, 0, (rect.size.height - self.font.lineHeight) / 2.0);
+        [self.placeholder drawInRect:rect withAttributes:@{NSFontAttributeName:self.font, NSForegroundColorAttributeName:_placeholderTextColor}];
+    }
+    else {
+    #pragma clang diagnostic push
+    #pragma clang diagnostic ignored "-Wenum-conversion"
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_6_0
+        [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:NSLineBreakByTruncatingTail alignment:self.textAlignment];
+    #else
+        [self.placeholder drawInRect:rect withFont:self.font lineBreakMode:UILineBreakModeTailTruncation alignment:self.textAlignment];
+    #endif
+    #pragma clang diagnostic pop
+    }
+}
 
 #pragma mark - Private
 
 - (void)initialize {
-  self.textEdgeInsets = UIEdgeInsetsZero;
-  self.clearButtonEdgeInsets = UIEdgeInsetsZero;
+    self.textEdgeInsets = UIEdgeInsetsZero;
+    self.clearButtonEdgeInsets = UIEdgeInsetsZero;
     self.leftViewInsets = UIEdgeInsetsZero;
     self.rightViewInsets = UIEdgeInsetsZero;
 }


### PR DESCRIPTION
In iOS7 all methods like like drawInRect:withFont: are deprecated and give the wrong text appearance (always aligned to top). Rect should be adopted for vertically centering text. 

Example of incorrect placeholder position:
![Placeholder](http://habrastorage.org/storage3/3e3/aa2/b48/3e3aa2b482d57c3c46c216adbd5b83cc.jpg)

Added rect adjustments for iOS 7 as adviced [here](http://stackoverflow.com/a/3396065/2797141):

``` objective-c
CGRectInset(rect, 0, (rect.size.height - self.font.lineHeight) / 2.0);
```
