### PR TITLE
Placeholder rect should normally match text rect

### DIFF
--- a/SAMTextField/SAMTextField.m
+++ b/SAMTextField/SAMTextField.m
@@ -40,6 +40,11 @@
 }
 
 
+- (CGRect)placeholderRectForBounds:(CGRect)bounds {
+  return [self textRectForBounds:bounds];
+}
+
+
 - (CGRect)clearButtonRectForBounds:(CGRect)bounds {
     return UIEdgeInsetsInsetRect([super clearButtonRectForBounds:bounds], self.clearButtonEdgeInsets);
 }


### PR DESCRIPTION
Up to you if you want to add this, but I think it looks odd if the placeholder rect doesn't match the text rect (at least in the app where I'm using this)
